### PR TITLE
Fixa a opção de Dropbox para as operações na nuvem

### DIFF
--- a/GameSaveManager.View/Pages/SettingsPage.xaml
+++ b/GameSaveManager.View/Pages/SettingsPage.xaml
@@ -113,6 +113,7 @@
                            Grid.Column="0" />
                 <ComboBox x:Name="comboListaNuvem"
                           ItemsSource="{Binding Path=DriveServiceSelected, Converter={enumConverter:EnumToCollectionConverter}, Mode=OneTime}"
+                          IsEnabled="False"
                           SelectedValuePath="Value"
                           DisplayMemberPath="Description"
                           SelectedValue="{Binding Path=DriveServiceSelected}"

--- a/GameSaveManager.View/ViewModel/SettingsPageViewModel.cs
+++ b/GameSaveManager.View/ViewModel/SettingsPageViewModel.cs
@@ -59,7 +59,7 @@ namespace GameSaveManager.View.ViewModel
 
         private void Clear()
         {
-            DriveServiceSelected = DriveServicesEnum.GoogleDrive;
+            DriveServiceSelected = DriveServicesEnum.Dropbox;
         }
     }
 }


### PR DESCRIPTION
Fixes #2 

Bloqueia a opção de selecionar qual serviço de nuvem pode ser selecionado até que sejam implementados.